### PR TITLE
题干和提示中的code部分应使用代码块，而不是美元符号

### DIFF
--- a/leetcode-helper.js
+++ b/leetcode-helper.js
@@ -154,7 +154,7 @@
         turndownService.addRule('strikethrough', {
             filter: ['code'],
             replacement: function (content) {
-                return '$' + content + "$"
+                return '`' + content + "`"
             }
         });
         turndownService.addRule('strikethrough', {


### PR DESCRIPTION
以今天的[每日一题](https://leetcode.cn/problems/parsing-a-boolean-expression/)为例，使用美元符号生成的md文件会导致乱码。应用代码块符号。